### PR TITLE
Enable multi-arch docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM alpine:3.13.5
+#FROM alpine:3.13.5
+FROM --platform=$BUILDPLATFORM alpine:3.15.5 AS build
+
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN printf '..%s..' "I'm building for TARGETPLATFORM=${TARGETPLATFORM}" \
+    && printf '..%s..' ", TARGETARCH=${TARGETARCH}" \
+    && printf '..%s..' ", TARGETVARIANT=${TARGETVARIANT} \n" \
+    && printf '..%s..' "With uname -s : " && uname -s \
+    && printf '..%s..' "and  uname -m : " && uname -m
  
 RUN apk add --no-cache \
 	unbound=1.13.2-r0
@@ -10,9 +20,9 @@ RUN wget https://www.internic.net/domain/named.root -qO- >> /etc/unbound/root.hi
 COPY files/ /opt/
 
 # AdGuardHome v0.105.2
-RUN wget https://static.adguard.com/adguardhome/release/AdGuardHome_linux_arm64.tar.gz >/dev/null 2>&1 \
+RUN wget https://static.adguard.com/adguardhome/release/AdGuardHome_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz >/dev/null 2>&1 \
 	&& mkdir -p /opt/adguardhome/conf /opt/adguardhome/work \
-	&& tar xf AdGuardHome_linux_arm64.tar.gz ./AdGuardHome/AdGuardHome  --strip-components=2 -C /opt/adguardhome \
+	&& tar xf AdGuardHome_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz ./AdGuardHome/AdGuardHome  --strip-components=2 -C /opt/adguardhome \
 	&& /bin/ash /opt/adguardhome \
 	&& chown -R nobody: /opt/adguardhome \
 	&& setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' /opt/adguardhome/AdGuardHome \


### PR DESCRIPTION
Hi kopi1984, I notice you public the arm64 docker image for adguard-unbound to docker hub. Do you mind try to enable multi-arch for the docker image too?